### PR TITLE
Override storefront_product_search

### DIFF
--- a/inc/woocommerce/template-tags.php
+++ b/inc/woocommerce/template-tags.php
@@ -35,12 +35,14 @@ if ( ! function_exists( 'storefront_cart_link' ) ) {
  * @uses  is_woocommerce_activated() check if WooCommerce is activated
  * @return void
  */
-function storefront_product_search() {
-	if ( is_woocommerce_activated() ) { ?>
-		<div class="site-search">
-			<?php the_widget( 'WC_Widget_Product_Search', 'title=' ); ?>
-		</div>
-	<?php
+if ( ! function_exists( 'storefront_product_search' ) ) {
+	function storefront_product_search() {
+		if ( is_woocommerce_activated() ) { ?>
+			<div class="site-search">
+				<?php the_widget( 'WC_Widget_Product_Search', 'title=' ); ?>
+			</div>
+		<?php
+		}
 	}
 }
 


### PR DESCRIPTION
Let users override the function storefront_product_search.
When you use some plugins (eg. [WooCommerce Product Search](http://www.woothemes.com/products/woocommerce-product-search/)) you will probably want to use that AJAX form in the header.

Now you have to remove the action and add another one with a different function.