### PR TITLE
Fix for Footer showing wrong year for copyright...

### DIFF
--- a/inc/structure/footer.php
+++ b/inc/structure/footer.php
@@ -55,7 +55,7 @@ if ( ! function_exists( 'storefront_credit' ) ) {
 	function storefront_credit() {
 		?>
 		<div class="site-info">
-			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . get_the_date( 'Y' ) ) ); ?>
+			<?php echo esc_html( apply_filters( 'storefront_copyright_text', $content = '&copy; ' . get_bloginfo( 'name' ) . ' ' . date( 'Y' ) ) ); ?>
 			<?php if ( apply_filters( 'storefront_credit_link', true ) ) { ?>
 			<br /> <?php printf( __( '%1$s designed by %2$s.', 'storefront' ), 'Storefront', '<a href="http://woothemes.com" rel="designer">WooThemes</a>' ); ?>
 			<?php } ?>


### PR DESCRIPTION
get_the_date() pulls date from the current global post object. The date of the current post object may not be the actual current date. So using date() instead of get_the_date() to show correct current year.