### PR TITLE
Reorders the sidebar registrations such that the primary sidebar is registered first. Fixes #126.

### DIFF
--- a/inc/functions/setup.php
+++ b/inc/functions/setup.php
@@ -95,8 +95,8 @@ endif; // storefront_setup
  */
 function storefront_widgets_init() {
 	register_sidebar( array(
-		'name'          => __( 'Header', 'storefront' ),
-		'id'            => 'header-1',
+		'name'          => __( 'Sidebar', 'storefront' ),
+		'id'            => 'sidebar-1',
 		'description'   => '',
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',
@@ -105,8 +105,8 @@ function storefront_widgets_init() {
 	) );
 
 	register_sidebar( array(
-		'name'          => __( 'Sidebar', 'storefront' ),
-		'id'            => 'sidebar-1',
+		'name'          => __( 'Header', 'storefront' ),
+		'id'            => 'header-1',
 		'description'   => '',
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',


### PR DESCRIPTION
@jameskoster Merge as desired.

Also, we should rename `sidebar-1` at some stage, as this is going to cause issues with many sidebars being generated, especially with a tool such as WooSidebars.