### PR TITLE
Uses get_cart_subtotal for header cart

### DIFF
--- a/inc/woocommerce/template-tags.php
+++ b/inc/woocommerce/template-tags.php
@@ -22,7 +22,7 @@ if ( ! function_exists( 'storefront_cart_link' ) ) {
 		?>
 		<li class="<?php echo esc_attr( $class ); ?>">
 			<a class="cart-contents" href="<?php echo esc_url( WC()->cart->get_cart_url() ); ?>" title="<?php _e( 'View your shopping cart', 'storefront' ); ?>">
-				<?php echo wp_kses_data( WC()->cart->get_cart_total() ); ?> <span class="count"><?php echo wp_kses_data( sprintf( _n( '%d item', '%d items', WC()->cart->get_cart_contents_count(), 'storefront' ), WC()->cart->get_cart_contents_count() ) );?></span>
+				<?php echo wp_kses_data( WC()->cart->get_cart_subtotal() ); ?> <span class="count"><?php echo wp_kses_data( sprintf( _n( '%d item', '%d items', WC()->cart->get_cart_contents_count(), 'storefront' ), WC()->cart->get_cart_contents_count() ) );?></span>
 			</a>
 		</li>
 		<?php


### PR DESCRIPTION
I think we should use `get_cart_subtotal` instead of `get_cart_total` for the header cart.

This is because if i have taxes enabled and prices excl. tax, but show prices incl. taxes in the cart/checkout, then the header cart shows the prices excl. taxes.

For me makes more sense to show them taxes incl. there too since it's a cart.