### PR TITLE
Download languages files from Transifex and create .mo files

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[storefront-1.storefront]
+file_filter = languages/<lang>.po
+source_file = languages/storefront.pot
+source_lang = en
+type = PO

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -246,14 +246,14 @@ module.exports = function( grunt ) {
 		'cssmin'
 	]);
 
-	grunt.registerTask( 'dev', [
-		'default',
-		'makepot'
-	]);
-
 	grunt.registerTask( 'tx_update', [
 		'makepot',
 		'shell:txpush'
+	]);
+
+	grunt.registerTask( 'dev', [
+		'default',
+		'tx_update'
 	]);
 
 	grunt.registerTask( 'mo', [
@@ -262,6 +262,7 @@ module.exports = function( grunt ) {
 	]);
 
 	grunt.registerTask( 'deploy', [
+		'mo',
 		'copy'
 	]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,9 @@ module.exports = function( grunt ) {
 			frontend: {
 				options: {
 					potFilename: 'storefront.pot',
+					exclude: [
+						'storefront/.*' // Exclude deploy directory
+					],
 					processPot: function ( pot ) {
 						pot.headers['project-id-version'];
 						return pot;
@@ -184,8 +187,40 @@ module.exports = function( grunt ) {
 				expand: true,
 				dot: true
 			}
-		}
+		},
 
+		// Shell actions for transifex client
+		shell: {
+			options: {
+				stdout: true,
+				stderr: true
+			},
+			txpush: {
+				command: 'tx push -s' // push the resources
+			},
+			txpull: {
+				command: 'tx pull -a -f' // pull the .po files
+			}
+		},
+
+		// Convert .po to .mo
+		potomo: {
+			options: {
+				poDel: false
+			},
+			dist: {
+				files: [{
+					expand: true,
+					cwd: 'languages/',
+					src: [
+						'*.po'
+					],
+					dest: 'languages/',
+					ext: '.mo',
+					nonull: true
+				}]
+			}
+		}
 	});
 
 	// Load NPM tasks to be used here
@@ -197,6 +232,8 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 	grunt.loadNpmTasks( 'grunt-checktextdomain' );
 	grunt.loadNpmTasks( 'grunt-contrib-copy' );
+	grunt.loadNpmTasks( 'grunt-shell' );
+	grunt.loadNpmTasks( 'grunt-potomo' );
 
 	// Register tasks
 	grunt.registerTask( 'default', [
@@ -212,6 +249,16 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'dev', [
 		'default',
 		'makepot'
+	]);
+
+	grunt.registerTask( 'tx_update', [
+		'makepot',
+		'shell:txpush'
+	]);
+
+	grunt.registerTask( 'mo', [
+		'shell:txpull',
+		'potomo'
 	]);
 
 	grunt.registerTask( 'deploy', [

--- a/languages/storefront.pot
+++ b/languages/storefront.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Storefront 1.4.3\n"
+"Project-Id-Version: Storefront 1.4.4\n"
 "Report-Msgid-Bugs-To: https://github.com/woothemes/storefront/issues\n"
-"POT-Creation-Date: 2015-04-08 10:55:40+00:00\n"
+"POT-Creation-Date: 2015-04-15 20:54:33+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "node-sass": "^2.1.1",
     "susy": "^2.2.2",
     "node-bourbon": "~4.2.1-beta1",
-    "grunt-contrib-copy": "~0.5.0"
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-potomo": "~3.2.1",
+    "grunt-shell": "~1.1.2"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
Hey @jameskoster 

Now you have the new Gruntasks:

- `tx_update`: Will create the .pot file and update the resourse in Transifex.
- `mo`: Will pull the .po files from Transifex and create .mo files

I also changed some tasks:

- `dev`: Runs the `default` and `tx_update` tasks.
- `deploy`: Rusn the `mo` and `copy` tasks.

For now I did not have any commits to the translations files.
However I believe that we could use the .gitignore not to push translations (.mo and .po) and this way you will have them only at WordPress.org, when running the `copy` task.
But that part is up to you, I'm just suggesting :p