### PR TITLE
Increase readability for debug info

### DIFF
--- a/inc/woocommerce/css/woocommerce.scss
+++ b/inc/woocommerce/css/woocommerce.scss
@@ -1209,6 +1209,10 @@ p.no-comments {
 			opacity: 0.7;
 		}
 	}
+
+	pre.debug_info {
+		color: #484c51;
+	}
 }
 
 .wc-forward {

--- a/inc/woocommerce/css/woocommerce.scss
+++ b/inc/woocommerce/css/woocommerce.scss
@@ -1210,8 +1210,8 @@ p.no-comments {
 		}
 	}
 
-	pre.debug_info {
-		color: #484c51;
+	pre {
+		background-color: rgba(0,0,0,.1);
 	}
 }
 


### PR DESCRIPTION
As is, the debug logs are pretty hard to read, and require cursor highlighting. This is a simple patch to darken the text:)

Before: http://cld.wthms.co/1eXrC
After: http://cld.wthms.co/1diUi