### PR TITLE
Check to see if "Layout_Picker_Storefront_Control" class exists

### DIFF
--- a/inc/customizer/controls/layout.php
+++ b/inc/customizer/controls/layout.php
@@ -2,6 +2,7 @@
 /**
  * Class to create a custom layout control
  */
+if (!class_exists('Layout_Picker_Storefront_Control')) { 
 class Layout_Picker_Storefront_Control extends WP_Customize_Control {
 
 	/**
@@ -25,4 +26,5 @@ class Layout_Picker_Storefront_Control extends WP_Customize_Control {
 		</div>
 		<?php
 	}
+}
 }


### PR DESCRIPTION
This will allow child themes to override Layout options. (we created a child theme that offers a 1 column layout, so had to override this class)