### PR TITLE
Wrap the place order button on line breaks so buttons don't wrap on characters.

### DIFF
--- a/inc/woocommerce/css/woocommerce.scss
+++ b/inc/woocommerce/css/woocommerce.scss
@@ -838,6 +838,7 @@ form.checkout {
 		.button {
 			font-size: 1.387em;
 			width: 100%;
+			white-space: pre-wrap;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #214.

Slightly longer button titles provided by gateways can wrap in the wrong place. For example "Request Confirmation" from the WC Bookings plugin was causing the following to happen:

![](https://cldup.com/5_sEBbHBfD-3000x3000.png)

This tiny PR tells the button to wrap on line breaks when possible to avoid that from happening:

![](https://cldup.com/T_DYLka3hD-3000x3000.png)


