### PR TITLE
Shop sorting texts getting double lines

### DIFF
--- a/inc/woocommerce/css/woocommerce.scss
+++ b/inc/woocommerce/css/woocommerce.scss
@@ -1626,7 +1626,7 @@ dl.variation {
 		margin-bottom: 2.618em;
 
 		select {
-			width: 9.505em;
+			width: auto;
 		}
 	}
 


### PR DESCRIPTION
Fix for https://github.com/woothemes/storefront/issues/216

Screenshot (Chrome): 
![image](https://cloud.githubusercontent.com/assets/3819579/9344110/1eea4354-4628-11e5-91c3-af3000fbe952.png)

Screenshot (Opera): 
![image](https://cloud.githubusercontent.com/assets/3819579/9344128/37dc6f04-4628-11e5-92f6-5ba2ff115299.png)
