### PR TITLE
Better enqueue RTL resources.

### DIFF
--- a/inc/functions/setup.php
+++ b/inc/functions/setup.php
@@ -143,11 +143,9 @@ function storefront_widgets_init() {
 function storefront_scripts() {
 	global $storefront_version;
 
-	if ( is_rtl() ) {
-		wp_enqueue_style( 'storefront-style', get_stylesheet_directory_uri() . '/style-rtl.css', $storefront_version );
-	} else {
-		wp_enqueue_style( 'storefront-style', get_stylesheet_uri(), '', $storefront_version );
-	}
+
+	wp_enqueue_style( 'storefront-style', get_stylesheet_uri(), '', $storefront_version );
+	wp_style_add_data( 'storefront-style', 'rtl', 'replace' );
 
 	wp_enqueue_script( 'storefront-navigation', get_template_directory_uri() . '/js/navigation.min.js', array(), '20120206', true );
 

--- a/inc/woocommerce/functions.php
+++ b/inc/woocommerce/functions.php
@@ -85,11 +85,8 @@ if ( ! function_exists( 'storefront_cart_link_fragment' ) ) {
 function storefront_woocommerce_scripts() {
 	global $storefront_version;
 
-	if ( is_rtl() ) {
-		wp_enqueue_style( 'storefront-woocommerce-style', get_template_directory_uri() . '/inc/woocommerce/css/woocommerce-rtl.css', $storefront_version );
-	} else {
-		wp_enqueue_style( 'storefront-woocommerce-style', get_template_directory_uri() . '/inc/woocommerce/css/woocommerce.css', $storefront_version );
-	}
+	wp_enqueue_style( 'storefront-woocommerce-style', get_template_directory_uri() . '/inc/woocommerce/css/woocommerce.css', $storefront_version );
+	wp_style_add_data( 'storefront-woocommerce-style', 'rtl', 'replace' );
 }
 
 /**

--- a/inc/woocommerce/integrations.php
+++ b/inc/woocommerce/integrations.php
@@ -14,121 +14,88 @@ function storefront_woocommerce_integrations_scripts() {
 	 * Bookings
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Bookings' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-bookings-style', get_template_directory_uri() . '/inc/woocommerce/css/bookings-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-bookings-style', get_template_directory_uri() . '/inc/woocommerce/css/bookings.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-bookings-style', get_template_directory_uri() . '/inc/woocommerce/css/bookings.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-bookings-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * Brands
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Brands' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-brands-style', get_template_directory_uri() . '/inc/woocommerce/css/brands-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-brands-style', get_template_directory_uri() . '/inc/woocommerce/css/brands.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-brands-style', get_template_directory_uri() . '/inc/woocommerce/css/brands.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-brands-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * Wishlists
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Wishlists_Wishlist' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-wishlists-style', get_template_directory_uri() . '/inc/woocommerce/css/wishlists-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-wishlists-style', get_template_directory_uri() . '/inc/woocommerce/css/wishlists.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-wishlists-style', get_template_directory_uri() . '/inc/woocommerce/css/wishlists.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-wishlists-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * AJAX Layered Nav
 	 */
 	if ( is_woocommerce_extension_activated( 'SOD_Widget_Ajax_Layered_Nav' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-ajax-layered-nav-style', get_template_directory_uri() . '/inc/woocommerce/css/ajax-layered-nav-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-ajax-layered-nav-style', get_template_directory_uri() . '/inc/woocommerce/css/ajax-layered-nav.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-ajax-layered-nav-style', get_template_directory_uri() . '/inc/woocommerce/css/ajax-layered-nav.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-ajax-layered-nav-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * Variation Swatches
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_SwatchesPlugin' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-variation-swatches-style', get_template_directory_uri() . '/inc/woocommerce/css/variation-swatches-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-variation-swatches-style', get_template_directory_uri() . '/inc/woocommerce/css/variation-swatches.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-variation-swatches-style', get_template_directory_uri() . '/inc/woocommerce/css/variation-swatches.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-variation-swatches-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * Composite Products
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Composite_Products' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-composite-products-style', get_template_directory_uri() . '/inc/woocommerce/css/composite-products-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-composite-products-style', get_template_directory_uri() . '/inc/woocommerce/css/composite-products.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-composite-products-style', get_template_directory_uri() . '/inc/woocommerce/css/composite-products.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-composite-products-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * WooCommerce Photography
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Photography' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-photography-style', get_template_directory_uri() . '/inc/woocommerce/css/photography-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-photography-style', get_template_directory_uri() . '/inc/woocommerce/css/photography.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-photography-style', get_template_directory_uri() . '/inc/woocommerce/css/photography.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-photography-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * Product Reviews Pro
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Product_Reviews_Pro' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-product-reviews-pro-style', get_template_directory_uri() . '/inc/woocommerce/css/product-reviews-pro-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-product-reviews-pro-style', get_template_directory_uri() . '/inc/woocommerce/css/product-reviews-pro.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-product-reviews-pro-style', get_template_directory_uri() . '/inc/woocommerce/css/product-reviews-pro.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-product-reviews-pro-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * WooCommerce Smart Coupons
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Smart_Coupons' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-smart-coupons-style', get_template_directory_uri() . '/inc/woocommerce/css/smart-coupons-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-smart-coupons-style', get_template_directory_uri() . '/inc/woocommerce/css/smart-coupons.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-smart-coupons-style', get_template_directory_uri() . '/inc/woocommerce/css/smart-coupons.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-smart-coupons-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * WooCommerce Deposits
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Deposits' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-deposits-style', get_template_directory_uri() . '/inc/woocommerce/css/deposits-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-deposits-style', get_template_directory_uri() . '/inc/woocommerce/css/deposits.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-deposits-style', get_template_directory_uri() . '/inc/woocommerce/css/deposits.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-deposits-style', 'rtl', 'replace' );
 	}
 
 	/**
 	 * WooCommerce Product Bundles
 	 */
 	if ( is_woocommerce_extension_activated( 'WC_Bundles' ) ) {
-		if ( is_rtl() ) {
-			wp_enqueue_style( 'storefront-woocommerce-bundles-style', get_template_directory_uri() . '/inc/woocommerce/css/bundles-rtl.css', 'storefront-woocommerce-style' );
-		} else {
-			wp_enqueue_style( 'storefront-woocommerce-bundles-style', get_template_directory_uri() . '/inc/woocommerce/css/bundles.css', 'storefront-woocommerce-style' );
-		}
+		wp_enqueue_style( 'storefront-woocommerce-bundles-style', get_template_directory_uri() . '/inc/woocommerce/css/bundles.css', 'storefront-woocommerce-style' );
+		wp_style_add_data( 'storefront-woocommerce-bundles-style', 'rtl', 'replace' );
 	}
 }
 


### PR DESCRIPTION
Instead of toggling the stylesheet that’s enqueued, just tell Core where both of them are, and let Core handle the swapping in a ‘late-binding’ fashion.

Relevant core code:
https://github.com/WordPress/WordPress/blob/809baf442b/wp-includes/class.wp-styles.php#L88-L104

Also, if Storefront ever later migrates to shipping minified versions of these css in addition the normal css sources, you can specify a .min suffix like this:

```php
wp_style_add_data( 'example', 'suffix', $min );
```