### PR TITLE
Add responsive width for embed elements

### DIFF
--- a/sass/components/_media.scss
+++ b/sass/components/_media.scss
@@ -64,3 +64,13 @@
 	}
 
 }
+
+/**
+ * Embeds
+ */
+embed,
+iframe,
+object,
+video {
+	max-width: 100%;
+}


### PR DESCRIPTION
Fixes bug where embedded objects don't respond to screen width.
Example: http://mikey.link/1a2Du/35J1VCnD

With Fix: http://mikey.link/1b6tf/1NlDpeMB