### PR TITLE
Add support for tabular bundles mini-extension

### DIFF
--- a/inc/woocommerce/css/bundles.scss
+++ b/inc/woocommerce/css/bundles.scss
@@ -11,7 +11,7 @@
 @import '../../../node_modules/susy/sass/susy';
 
 .bundle_form {
-	.bundled_product_summary {
+	div.bundled_product_summary {
 		padding-bottom: 1.618em !important;
 		margin-bottom: 1.618em;
 		border-bottom: 1px solid $color_border;
@@ -25,7 +25,7 @@
 
 @media screen and (min-width: 768px) {
 	.bundle_form {
-		.bundled_product_summary {
+		div.bundled_product_summary {
 			padding-left: 0;
 			.bundled_product_images {
 				margin-left: 0;
@@ -45,7 +45,7 @@
 				font-size: .857em;
 			}
 		}
-		.bundled_product_summary.thumbnail_hidden {
+		div.bundled_product_summary.thumbnail_hidden {
 			padding-left: 0;
 			.details {
 				@include span( 10 of 10 );
@@ -56,7 +56,7 @@
 	.page-template-template-fullwidth-php,
 	.storefront-full-width-content {
 		.bundle_form {
-			.bundled_product_summary {
+			div.bundled_product_summary {
 				padding-left: 0;
 				.bundled_product_images {
 					margin-left: 0;
@@ -68,7 +68,7 @@
 					font-size: 1em;
 				}
 			}
-			.bundled_product_summary.thumbnail_hidden {
+			div.bundled_product_summary.thumbnail_hidden {
 				padding-left: 0;
 				.details {
 					@include span( 8 of 8 );


### PR DESCRIPTION
https://github.com/somewherewarm/woocommerce-product-bundles-tabular-layout - mimics the Grouped Products layout (table).

Current Storefront integration applies some rules that break the tabular layout, so I've retargeted those using `div` selectors (become `tr` when applying the tabular layout, no need to apply any custom styles there).