### PR TITLE
removed comma to validate json and fix npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node-sass":              "^3.2.0",
     "susy":                   "^2.2.5",
     "node-bourbon":           "~4.2.3",
-    "grunt-contrib-copy":     "~0.8.0",
+    "grunt-contrib-copy":     "~0.8.0"
   },
   "engines": {
     "node":                   ">=0.8.0",


### PR DESCRIPTION
I believe that comma needs to come out to fix a json parse error i get when I do npm install. As soon as I removed it I could complete npm install.