### PR TITLE
Improve grunt workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,7 +115,7 @@ module.exports = function( grunt ) {
 					'inc/customizer/js/*js',
 					'!inc/customizer/js/*.min.js'
 				],
-				tasks: ['uglify']
+				tasks: ['jshint', 'uglify']
 			}
 		},
 
@@ -179,6 +179,7 @@ module.exports = function( grunt ) {
 				src: [
 					'**',
 					'!.*',
+					'!*.md',
 					'!.*/**',
 					'.htaccess',
 					'!Gruntfile.js',
@@ -254,6 +255,7 @@ module.exports = function( grunt ) {
 	// Register tasks
 	grunt.registerTask( 'default', [
 		'css',
+		'jshint',
 		'uglify'
 	]);
 
@@ -265,12 +267,11 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( 'dev', [
 		'default',
-		'makepot',
-		'rtlcss'
+		'makepot'
 	]);
 
 	grunt.registerTask( 'deploy', [
-		'mo',
+		'dev',
 		'copy'
 	]);
 };


### PR DESCRIPTION
@jameskoster Following improvements:

* Exclude markdown files for deploy.
* Check linting errors before minification of scripts.
* No need of `rtlcss` in `grunt dev` as its included by default.
* In `grunt deploy` there exist no `mo` task so let's add `dev` tasks ;)

Simple!