### PR TITLE
Composite Products integration tweaks

### DIFF
--- a/inc/woocommerce/css/composite-products.scss
+++ b/inc/woocommerce/css/composite-products.scss
@@ -76,14 +76,20 @@
 			}
 		}
 
-		.component_content,
-		.component_options {
-			padding: 0;
+		> div {
+			padding-left: 0;
 		}
 
 		.select_label {
 			display: block;
 			margin-bottom: 1em;
+		}
+
+		.clear_component_options:before {
+			content: "\f021";
+			font-weight: 400;
+			font-family: FontAwesome;
+			margin-right: .53em;
 		}
 
 		.component_option_thumbnails {


### PR DESCRIPTION
- Styles the 'Clear selections' button in a way similar to `a.reset_variations`:

ref: http://cl.ly/image/3D0X3L0U2l0k

- Fixes an issue with padding + div elements wrapped under `component_selections`. The existing rule does not remove the left padding from all child divs and in a couple instances incorrectly removes the bottom padding.