### PR TITLE
Adds logic to adjust to full-width layout if the main sidebar doesn't contain any widgets.

### DIFF
--- a/inc/functions/extras.php
+++ b/inc/functions/extras.php
@@ -54,6 +54,11 @@ function storefront_body_classes( $classes ) {
 		$classes[] = 'storefront-cute';
 	}
 
+	// If our main sidebar doesn't contain widgets, adjust the layout to be full-width.
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+		$classes[] = 'storefront-full-width-content';
+	}
+
 	return $classes;
 }
 


### PR DESCRIPTION
When it comes to the question of sidebars and widgets in themes, there seem to be 2 general approaches:

1. Display some text in the widget area, encouraging the website administrator to add widgets (*cringe*).
2. Leave a blank space where the widgets should be (no direct education for the website administrator about what elements are missing).

This pull request introduces a third option, where by we adjust the layout to be full width if no widgets are present in the sidebar.

As widgets are added by default to the main sidebar, we can make a few assumptions:
1. If the website administrator doesn't want widgets in the sidebar, they'll remove these widgets.
2. If the widgets are removed, and the sidebar remains empty, the website administrator doesn't want a sidebar.
3. Not many website administrators enjoy a large gap of white space next to their content. :)

While a small change (3 lines of code), I feel this change would make a significant impact in assisting store owners to get up and running as quickly as possible, without the need to a) write code to get rid of the large blank space (which they'll most likely do using CSS in a hack-y manner, which disrupts our grid), or to purchase our WooCommerce Customizer extension for Storefront and begrudgingly spend money with us for one small feature which the theme should provide out of the box. While we want folks to buy extensions from us, this should be a purchase made willingly, not begrudgingly.

Thoughts? :)

@jameskoster @tiagonoronha @jeffikus @stuartduff @ianstewart 
