### PR TITLE
Minify style.css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,6 +108,11 @@ module.exports = function( grunt ) {
 
 		// Minify all .css files.
 		cssmin: {
+			main: {
+				files: {
+					'style.css': ['style.css']
+				}
+			},
 			admin: {
 				expand: true,
 				cwd: 'assets/sass/admin/welcome-screen/',

--- a/assets/sass/vendors/_normalize.scss
+++ b/assets/sass/vendors/_normalize.scss
@@ -1,4 +1,6 @@
-/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+/*!
+ * normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css
+ */
 
 /**
  * 1. Set default font family to sans-serif.

--- a/style.scss
+++ b/style.scss
@@ -1,4 +1,4 @@
-/*
+/*!
 Theme Name:   	Storefront
 Theme URI:    	http://www.woothemes.com/storefront
 Author:       	WooThemes


### PR DESCRIPTION
Fixes https://github.com/woothemes/storefront/issues/314 and preserves WP comments in `style.css`.
Also preserves the comment for normalize.scss since it's a vendor's file.