### PR TITLE
Added check for existence of secondary nav menu

### DIFF
--- a/inc/storefront-template-functions.php
+++ b/inc/storefront-template-functions.php
@@ -213,18 +213,20 @@ if ( ! function_exists( 'storefront_secondary_navigation' ) ) {
 	 * @return void
 	 */
 	function storefront_secondary_navigation() {
-		?>
-		<nav class="secondary-navigation" role="navigation" aria-label="<?php esc_html_e( 'Secondary Navigation', 'storefront' ); ?>">
-			<?php
-				wp_nav_menu(
-					array(
-						'theme_location'	=> 'secondary',
-						'fallback_cb'		=> '',
-					)
-				);
-			?>
-		</nav><!-- #site-navigation -->
-		<?php
+	    if ( has_nav_menu( 'secondary' ) ) {
+		    ?>
+		    <nav class="secondary-navigation" role="navigation" aria-label="<?php esc_html_e( 'Secondary Navigation', 'storefront' ); ?>">
+			    <?php
+				    wp_nav_menu(
+					    array(
+						    'theme_location'	=> 'secondary',
+						    'fallback_cb'		=> '',
+					    )
+				    );
+			    ?>
+		    </nav><!-- #site-navigation -->
+		    <?php
+		}
 	}
 }
 


### PR DESCRIPTION
If not using a secondary nav menu, you end up with an empty <nav> tag which
messes up the layout of the search bar which get pushed below the title/logo.
This also causes the header to be larger than desired and looks terrible.
This patch simply checks for the existence of a secondary menu before it outputs
the <nav> tags, thus not echoing an empty <nav> tag if you don't use a secondary
nav menu.