### PR TITLE
Remove zero margins in bundles.scss

### DIFF
--- a/assets/sass/woocommerce/bundles.scss
+++ b/assets/sass/woocommerce/bundles.scss
@@ -15,11 +15,6 @@
 		padding-bottom: 1.618em !important;
 		margin-bottom: 1.618em;
 		border-bottom: 1px solid $color_border;
-		p.stock,
-		.price {
-			margin-bottom: 0 !important;
-			margin-top: 0 !important;
-		}
 	}
 }
 


### PR DESCRIPTION
Just noticed this in the WC Bundles integration sass - is the zero-margin rule critical? 
Can't think of any reason to eliminate the default margins there.