### PR TITLE
Structured Data Fix & Tweaks

### DIFF
--- a/inc/woocommerce/storefront-woocommerce-template-functions.php
+++ b/inc/woocommerce/storefront-woocommerce-template-functions.php
@@ -335,37 +335,49 @@ if ( ! function_exists( 'storefront_woocommerce_init_structured_data' ) ) {
    * Apply the `storefront_woocommerce_structured_data` filter hook for structured data customization...
    */
   function storefront_woocommerce_init_structured_data() {
-    if ( ! is_product_category() ) return;
+    if ( ! is_product_category() ) {
+      return;
+    }
+
     global $product;
 
     $json['@type']             = 'Product';
+    $json['@id']               = 'product-' . get_the_ID();
     $json['name']              = get_the_title();
     $json['image']             = wp_get_attachment_url( $product->get_image_id() );
     $json['description']       = get_the_excerpt();
+    $json['url']               = get_the_permalink();
     $json['sku']               = $product->get_sku();
     $json['brand']             = array(
       '@type'                  => 'Thing',
       'name'                   => $product->get_attribute( __( 'brand', 'storefront' ) )
     );
+    
     if ( $product->get_rating_count() ) {
       $json['aggregateRating'] = array(
         '@type'                => 'AggregateRating',
         'ratingValue'          => $product->get_average_rating(),
-        'reviewCount'          => $product->get_rating_count()
+        'ratingCount'          => $product->get_rating_count(),
+        'reviewCount'          => $product->get_review_count()
       );
     }
+    
     $json['offers']            = array(
       '@type'                  => 'Offer',
       'priceCurrency'          => get_woocommerce_currency(),
       'price'                  => $product->get_price(),
       'itemCondition'          => 'http://schema.org/NewCondition',
-      'availability'           => 'http://schema.org/' . $stock = ( $product->is_in_stock ? 'InStock' : 'OutOfStock' ),
+      'availability'           => 'http://schema.org/' . $stock = ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
       'seller'                 => array(
         '@type'                => 'Organization',
         'name'                 => get_bloginfo( 'name' )
       )
     );
-    if ( ! isset( $json ) ) return;
+    
+    if ( ! isset( $json ) ) {
+      return;
+    }
+    
     Storefront::set_structured_data( apply_filters( 'storefront_woocommerce_structured_data', $json ) );
   }
 }


### PR DESCRIPTION
I've noticed a bug on line 370 when I was preparing this [PR for woocommerce](https://github.com/woothemes/woocommerce/pull/11455).
So let's keep in mind that if they accept it, we'll have to delete the `storefront_woocommerce_init_structured_data` function when they will merge it to the stable Woocommerce.