### PR TITLE
Fixed missing %clearfix placeholder

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -192,7 +192,7 @@ body {
 .site-header,
 .site-content,
 .site-footer {
-	@extend %clearfix;
+	@include clearfix;
 }
 
 /**

--- a/assets/sass/components/_media.scss
+++ b/assets/sass/components/_media.scss
@@ -42,7 +42,7 @@ img {
  * Galleries
  */
 .gallery {
-	@extend %clearfix;
+	@include clearfix;
 	margin-bottom: $vspacing;
 
 	.gallery-item {


### PR DESCRIPTION
I had to change this, since looks like we don't have any `%clearfix` placeholder on Storefront. And of course, or we use a mixin or a placeholder :P

```
$ grunt sass
Running "sass:dist" (sass) task
>> Error: ".clear" failed to @extend "%clearfix".
>>        The selector "%clearfix" was not found.
>>        Use "@extend %clearfix !optional" if the extend should be able to fail.
>>         on line 195 of assets/sass/base/_base.scss
>> >> 	@extend %clearfix;
>>    -^
Warning:  Use --force to continue.
```